### PR TITLE
https stuff from heroku

### DIFF
--- a/src/main/java/com/googhcl/hellojwt/config/WebSecurityConfig.java
+++ b/src/main/java/com/googhcl/hellojwt/config/WebSecurityConfig.java
@@ -38,6 +38,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .passwordEncoder(passwordEncoder());
     }
 
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -57,7 +58,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests().antMatchers("/authenticate", "/register")
                 .permitAll().
                 // all other requests need to be authenticated
-                anyRequest().authenticated().and().cors().and().
+                anyRequest().authenticated().and().cors().and().requiresChannel()
+                .requestMatchers(r -> r.getHeader("X-Forwarded-Proto") != null)
+                .requiresSecure().and().
                 // make sure we use stateless session; session won't be used to
                 // store user's state.
                 exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)


### PR DESCRIPTION
This configuration tells Spring to redirect all plain HTTP requests back to the same URL using HTTPS if the X-Forwarded-Proto header is present. Heroku sets the X-Forwarded-Proto header for you, which means the request will be redirected back through the Heroku router where SSL is terminated. In your localhost environment, you can continue to use plain HTTP.

[See Heroku Doc](https://devcenter.heroku.com/articles/preparing-a-spring-boot-app-for-production-on-heroku)